### PR TITLE
implement editable field for user name in settings

### DIFF
--- a/apps/dokploy/components/dashboard/settings/profile/profile-form.tsx
+++ b/apps/dokploy/components/dashboard/settings/profile/profile-form.tsx
@@ -32,6 +32,7 @@ import { Disable2FA } from "./disable-2fa";
 import { Enable2FA } from "./enable-2fa";
 
 const profileSchema = z.object({
+	name: z.string().nullable(),
 	email: z.string(),
 	password: z.string().nullable(),
 	currentPassword: z.string().nullable(),
@@ -79,6 +80,7 @@ export const ProfileForm = () => {
 
 	const form = useForm<Profile>({
 		defaultValues: {
+			name: data?.user?.name || "",
 			email: data?.user?.email || "",
 			password: "",
 			image: data?.user?.image || "",
@@ -92,6 +94,7 @@ export const ProfileForm = () => {
 		if (data) {
 			form.reset(
 				{
+					name: data?.user?.name || "",
 					email: data?.user?.email || "",
 					password: form.getValues("password") || "",
 					image: data?.user?.image || "",
@@ -114,6 +117,7 @@ export const ProfileForm = () => {
 
 	const onSubmit = async (values: Profile) => {
 		await mutateAsync({
+			name: values.name || undefined,
 			email: values.email.toLowerCase(),
 			password: values.password || undefined,
 			image: values.image,
@@ -124,6 +128,7 @@ export const ProfileForm = () => {
 				await refetch();
 				toast.success("Profile Updated");
 				form.reset({
+					name: values.name,
 					email: values.email,
 					password: "",
 					image: values.image,
@@ -167,6 +172,23 @@ export const ProfileForm = () => {
 										className="grid gap-4"
 									>
 										<div className="space-y-4">
+											<FormField
+												control={form.control}
+												name="name"
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel>{t("settings.profile.accountName")}</FormLabel>
+														<FormControl>
+															<Input
+																placeholder={t("settings.profile.accountName")}
+																{...field}
+																value={field.value || ""}
+															/>
+														</FormControl>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
 											<FormField
 												control={form.control}
 												name="email"

--- a/apps/dokploy/components/layouts/user-nav.tsx
+++ b/apps/dokploy/components/layouts/user-nav.tsx
@@ -49,7 +49,7 @@ export const UserNav = () => {
 						<AvatarFallback className="rounded-lg">CN</AvatarFallback>
 					</Avatar>
 					<div className="grid flex-1 text-left text-sm leading-tight">
-						<span className="truncate font-semibold">Account</span>
+						<span className="truncate font-semibold">{data?.user?.name || "Account"}</span>
 						<span className="truncate text-xs">{data?.user?.email}</span>
 					</div>
 					<ChevronsUpDown className="ml-auto size-4" />

--- a/apps/dokploy/public/locales/az/settings.json
+++ b/apps/dokploy/public/locales/az/settings.json
@@ -37,6 +37,7 @@
 
 	"settings.profile.title": "Hesab",
 	"settings.profile.description": "Profilinizin məlumatlarını buradan dəyişin.",
+	"settings.profile.accountName": "Ad",
 	"settings.profile.email": "E-poçt",
 	"settings.profile.password": "Şifrə",
 	"settings.profile.avatar": "Avatar",

--- a/apps/dokploy/public/locales/de/settings.json
+++ b/apps/dokploy/public/locales/de/settings.json
@@ -28,6 +28,7 @@
 
 	"settings.profile.title": "Konto",
 	"settings.profile.description": "Ändere die Details deines Profiles hier.",
+	"settings.profile.accountName": "Name",
 	"settings.profile.email": "E-Mail",
 	"settings.profile.password": "Passwort",
 	"settings.profile.avatar": "Avatar",

--- a/apps/dokploy/public/locales/en/settings.json
+++ b/apps/dokploy/public/locales/en/settings.json
@@ -37,6 +37,7 @@
 
 	"settings.profile.title": "Account",
 	"settings.profile.description": "Change the details of your profile here.",
+	"settings.profile.accountName": "Name",
 	"settings.profile.email": "Email",
 	"settings.profile.password": "Password",
 	"settings.profile.avatar": "Avatar",

--- a/apps/dokploy/public/locales/es/settings.json
+++ b/apps/dokploy/public/locales/es/settings.json
@@ -36,6 +36,7 @@
 
 	"settings.profile.title": "Cuenta",
 	"settings.profile.description": "Cambia los detalles de tu perfil aquí.",
+	"settings.profile.accountName": "Nombre",
 	"settings.profile.email": "Correo electrónico",
 	"settings.profile.password": "Contraseña",
 	"settings.profile.avatar": "Avatar",

--- a/apps/dokploy/public/locales/fa/settings.json
+++ b/apps/dokploy/public/locales/fa/settings.json
@@ -28,6 +28,7 @@
 
 	"settings.profile.title": "حساب کاربری",
 	"settings.profile.description": "جزئیات پروفایل خود را در اینجا تغییر دهید.",
+	"settings.profile.accountName": "نام",
 	"settings.profile.email": "ایمیل",
 	"settings.profile.password": "رمز عبور",
 	"settings.profile.avatar": "تصویر پروفایل",

--- a/apps/dokploy/public/locales/fr/settings.json
+++ b/apps/dokploy/public/locales/fr/settings.json
@@ -28,6 +28,7 @@
 
 	"settings.profile.title": "Compte",
 	"settings.profile.description": "Modifier les informations de votre compte ici.",
+	"settings.profile.accountName": "Nom",
 	"settings.profile.email": "Adresse Email",
 	"settings.profile.password": "Mot de passe",
 	"settings.profile.avatar": "Photo de profil",

--- a/apps/dokploy/public/locales/id/settings.json
+++ b/apps/dokploy/public/locales/id/settings.json
@@ -37,6 +37,7 @@
 
 	"settings.profile.title": "Akun",
 	"settings.profile.description": "Ubah detail profil Anda di sini.",
+	"settings.profile.accountName": "Nama",
 	"settings.profile.email": "Email",
 	"settings.profile.password": "Kata Sandi",
 	"settings.profile.avatar": "Avatar",

--- a/apps/dokploy/public/locales/it/settings.json
+++ b/apps/dokploy/public/locales/it/settings.json
@@ -28,6 +28,7 @@
 
 	"settings.profile.title": "Account",
 	"settings.profile.description": "Modifica i dettagli del tuo profilo qui.",
+	"settings.profile.accountName": "Nome",
 	"settings.profile.email": "Email",
 	"settings.profile.password": "Password",
 	"settings.profile.avatar": "Avatar",

--- a/apps/dokploy/public/locales/ja/settings.json
+++ b/apps/dokploy/public/locales/ja/settings.json
@@ -28,6 +28,7 @@
 
 	"settings.profile.title": "アカウント",
 	"settings.profile.description": "ここでプロフィールの詳細を変更できます",
+	"settings.profile.accountName": "名前",
 	"settings.profile.email": "メールアドレス",
 	"settings.profile.password": "パスワード",
 	"settings.profile.avatar": "アバター",

--- a/apps/dokploy/public/locales/ko/settings.json
+++ b/apps/dokploy/public/locales/ko/settings.json
@@ -28,6 +28,7 @@
 
 	"settings.profile.title": "계정",
 	"settings.profile.description": "여기에서 프로필 세부 정보를 변경하세요.",
+	"settings.profile.accountName": "이름",
 	"settings.profile.email": "이메일",
 	"settings.profile.password": "비밀번호",
 	"settings.profile.avatar": "아바타",

--- a/apps/dokploy/public/locales/kz/settings.json
+++ b/apps/dokploy/public/locales/kz/settings.json
@@ -26,6 +26,7 @@
 	"settings.server.webServer.storage.cleanAll": "Барлығын тазалау",
 	"settings.profile.title": "Аккаунт",
 	"settings.profile.description": "Профиль мәліметтерін осы жерден өзгертіңіз.",
+	"settings.profile.accountName": "Аты",
 	"settings.profile.email": "Эл. пошта",
 	"settings.profile.password": "Құпия сөз",
 	"settings.profile.avatar": "Аватар",

--- a/apps/dokploy/public/locales/ml/settings.json
+++ b/apps/dokploy/public/locales/ml/settings.json
@@ -37,6 +37,7 @@
 
 	"settings.profile.title": "അക്കൗണ്ട്",
 	"settings.profile.description": "നിങ്ങളുടെ പ്രൊഫൈൽ വിശദാംശങ്ങൾ ഇവിടെ മാറ്റുക.",
+	"settings.profile.accountName": "പേര്",
 	"settings.profile.email": "ഇമെയിൽ",
 	"settings.profile.password": "പാസ്വേഡ്",
 	"settings.profile.avatar": "അവതാർ",

--- a/apps/dokploy/public/locales/nl/settings.json
+++ b/apps/dokploy/public/locales/nl/settings.json
@@ -37,6 +37,7 @@
 
 	"settings.profile.title": "Account",
 	"settings.profile.description": "Veramder details van account.",
+	"settings.profile.accountName": "Naam",
 	"settings.profile.email": "Email",
 	"settings.profile.password": "Wachtwoord",
 	"settings.profile.avatar": "Profiel Icoon",

--- a/apps/dokploy/public/locales/no/settings.json
+++ b/apps/dokploy/public/locales/no/settings.json
@@ -36,6 +36,7 @@
 
 	"settings.profile.title": "Konto",
 	"settings.profile.description": "Endre detaljene for profilen din her.",
+	"settings.profile.accountName": "Navn",
 	"settings.profile.email": "Epost",
 	"settings.profile.password": "Passord",
 	"settings.profile.avatar": "Avatar",

--- a/apps/dokploy/public/locales/pl/settings.json
+++ b/apps/dokploy/public/locales/pl/settings.json
@@ -37,6 +37,7 @@
 
 	"settings.profile.title": "Konto",
 	"settings.profile.description": "Zmień szczegóły swojego profilu",
+	"settings.profile.accountName": "Imię",
 	"settings.profile.email": "Email",
 	"settings.profile.password": "Hasło",
 	"settings.profile.avatar": "Avatar",

--- a/apps/dokploy/public/locales/pt-br/settings.json
+++ b/apps/dokploy/public/locales/pt-br/settings.json
@@ -28,6 +28,7 @@
 
 	"settings.profile.title": "Conta",
 	"settings.profile.description": "Altere os detalhes do seu perfil aqui.",
+	"settings.profile.accountName": "Nome",
 	"settings.profile.email": "Email",
 	"settings.profile.password": "Senha",
 	"settings.profile.avatar": "Avatar",

--- a/apps/dokploy/public/locales/ru/settings.json
+++ b/apps/dokploy/public/locales/ru/settings.json
@@ -37,6 +37,7 @@
 
 	"settings.profile.title": "Аккаунт",
 	"settings.profile.description": "Измените данные вашего профиля.",
+	"settings.profile.accountName": "Имя",
 	"settings.profile.email": "Email",
 	"settings.profile.password": "Пароль",
 	"settings.profile.avatar": "Аватар",

--- a/apps/dokploy/public/locales/tr/settings.json
+++ b/apps/dokploy/public/locales/tr/settings.json
@@ -28,6 +28,7 @@
 
 	"settings.profile.title": "Hesap",
 	"settings.profile.description": "Profil detaylarınızı buradan değiştirebilirsiniz.",
+	"settings.profile.accountName": "İsim",
 	"settings.profile.email": "E-posta",
 	"settings.profile.password": "Şifre",
 	"settings.profile.avatar": "Profil Resmi",

--- a/apps/dokploy/public/locales/uk/settings.json
+++ b/apps/dokploy/public/locales/uk/settings.json
@@ -37,6 +37,7 @@
 
 	"settings.profile.title": "Обліковий запис",
 	"settings.profile.description": "Змініть дані вашого профілю.",
+	"settings.profile.accountName": "Ім'я",
 	"settings.profile.email": "Електронна пошта",
 	"settings.profile.password": "Пароль",
 	"settings.profile.avatar": "Аватар",

--- a/apps/dokploy/public/locales/zh-Hans/settings.json
+++ b/apps/dokploy/public/locales/zh-Hans/settings.json
@@ -35,6 +35,7 @@
 	"settings.server.webServer.storage.cleanAll": "清理所有内容",
 	"settings.profile.title": "账户",
 	"settings.profile.description": "在此更改您的个人资料详情。",
+	"settings.profile.accountName": "姓名",
 	"settings.profile.email": "邮箱",
 	"settings.profile.password": "密码",
 	"settings.profile.avatar": "头像",

--- a/apps/dokploy/public/locales/zh-Hant/settings.json
+++ b/apps/dokploy/public/locales/zh-Hant/settings.json
@@ -37,6 +37,7 @@
 
 	"settings.profile.title": "帳戶",
 	"settings.profile.description": "更改您的個人資料",
+	"settings.profile.accountName": "姓名",
 	"settings.profile.email": "信箱",
 	"settings.profile.password": "密碼",
 	"settings.profile.avatar": "頭像",


### PR DESCRIPTION
Closes #9 

CheckList
- [X] A Name input field is visible in the profile form UI
- [X] Name field is displayed on the bottom left of the side-panel replacing "Account"
- [X] The name field is properly integrated with the form validation schema as an optional field
- [X] The name value is correctly loaded from the user's existing profile data when the form initializes
- [X] When the form is submitted, the name value is included in the update request
- [X] After successful submission, the name field retains the updated value
- [X] ```npm test``` operation passed

https://github.com/user-attachments/assets/8a875e01-2c4a-4af2-ad52-46c9a1b70a23