### PR TITLE
feat: Add custom title/description support for API/CLI deployments

### DIFF
--- a/apps/dokploy/pages/api/deploy/[refreshToken].ts
+++ b/apps/dokploy/pages/api/deploy/[refreshToken].ts
@@ -179,10 +179,19 @@ export default async function handler(
 		}
 
 		try {
+
+			const titleLog =
+				req.query?.titleLog as string ||
+				deploymentTitle;
+
+			const descriptionLog =
+				req.query?.descriptionLog as string ||
+				`Hash: ${deploymentHash}`;
+
 			const jobData: DeploymentJob = {
 				applicationId: application.applicationId as string,
-				titleLog: deploymentTitle,
-				descriptionLog: `Hash: ${deploymentHash}`,
+				titleLog: titleLog,
+				descriptionLog: descriptionLog,
 				type: "deploy",
 				applicationType: "application",
 				server: !!application.serverId,

--- a/apps/dokploy/server/api/routers/application.ts
+++ b/apps/dokploy/server/api/routers/application.ts
@@ -6,6 +6,7 @@ import {
 import { db } from "@/server/db";
 import {
 	apiCreateApplication,
+	apiDeployApplication,
 	apiFindMonitoringStats,
 	apiFindOneApplication,
 	apiReloadApplication,
@@ -298,7 +299,7 @@ export const applicationRouter = createTRPCRouter({
 		}),
 
 	redeploy: protectedProcedure
-		.input(apiFindOneApplication)
+		.input(apiDeployApplication)
 		.mutation(async ({ input, ctx }) => {
 			const application = await findApplicationById(input.applicationId);
 			if (
@@ -311,8 +312,8 @@ export const applicationRouter = createTRPCRouter({
 			}
 			const jobData: DeploymentJob = {
 				applicationId: input.applicationId,
-				titleLog: "Rebuild deployment",
-				descriptionLog: "",
+				titleLog: input.titleLog || "Rebuild deployment",
+				descriptionLog: input.descriptionLog || "",
 				type: "redeploy",
 				applicationType: "application",
 				server: !!application.serverId,
@@ -648,7 +649,7 @@ export const applicationRouter = createTRPCRouter({
 			return true;
 		}),
 	deploy: protectedProcedure
-		.input(apiFindOneApplication)
+		.input(apiDeployApplication)
 		.mutation(async ({ input, ctx }) => {
 			const application = await findApplicationById(input.applicationId);
 			if (
@@ -661,8 +662,8 @@ export const applicationRouter = createTRPCRouter({
 			}
 			const jobData: DeploymentJob = {
 				applicationId: input.applicationId,
-				titleLog: "Manual deployment",
-				descriptionLog: "",
+				titleLog: input.titleLog || "Manual deployment",
+				descriptionLog: input.descriptionLog || "",
 				type: "deploy",
 				applicationType: "application",
 				server: !!application.serverId,

--- a/apps/dokploy/server/api/routers/compose.ts
+++ b/apps/dokploy/server/api/routers/compose.ts
@@ -3,6 +3,7 @@ import { db } from "@/server/db";
 import {
 	apiCreateCompose,
 	apiDeleteCompose,
+	apiDeployCompose,
 	apiFetchServices,
 	apiFindCompose,
 	apiRandomizeCompose,
@@ -315,7 +316,7 @@ export const composeRouter = createTRPCRouter({
 		}),
 
 	deploy: protectedProcedure
-		.input(apiFindCompose)
+		.input(apiDeployCompose)
 		.mutation(async ({ input, ctx }) => {
 			const compose = await findComposeById(input.composeId);
 
@@ -327,10 +328,10 @@ export const composeRouter = createTRPCRouter({
 			}
 			const jobData: DeploymentJob = {
 				composeId: input.composeId,
-				titleLog: "Manual deployment",
+				titleLog: input.titleLog || "Manual deployment",
 				type: "deploy",
 				applicationType: "compose",
-				descriptionLog: "",
+				descriptionLog: input.descriptionLog || "",
 				server: !!compose.serverId,
 			};
 
@@ -349,7 +350,7 @@ export const composeRouter = createTRPCRouter({
 			);
 		}),
 	redeploy: protectedProcedure
-		.input(apiFindCompose)
+		.input(apiDeployCompose)
 		.mutation(async ({ input, ctx }) => {
 			const compose = await findComposeById(input.composeId);
 			if (compose.project.organizationId !== ctx.session.activeOrganizationId) {
@@ -360,10 +361,10 @@ export const composeRouter = createTRPCRouter({
 			}
 			const jobData: DeploymentJob = {
 				composeId: input.composeId,
-				titleLog: "Rebuild deployment",
+				titleLog: input.titleLog || "Rebuild deployment",
 				type: "redeploy",
 				applicationType: "compose",
-				descriptionLog: "",
+				descriptionLog: input.descriptionLog || "",
 				server: !!compose.serverId,
 			};
 			if (IS_CLOUD && compose.serverId) {

--- a/packages/server/src/db/schema/application.ts
+++ b/packages/server/src/db/schema/application.ts
@@ -568,3 +568,13 @@ export const apiUpdateApplication = createSchema
 		applicationId: z.string().min(1),
 	})
 	.omit({ serverId: true });
+
+export const apiDeployApplication = createSchema
+	.pick({
+		applicationId: true,
+	})
+	.required()
+	.extend({
+		titleLog: z.string().optional(),
+		descriptionLog: z.string().optional(),
+	});

--- a/packages/server/src/db/schema/compose.ts
+++ b/packages/server/src/db/schema/compose.ts
@@ -204,3 +204,10 @@ export const apiRandomizeCompose = createSchema
 		suffix: z.string().optional(),
 		composeId: z.string().min(1),
 	});
+
+export const apiDeployCompose = z.object({
+	composeId: z.string().min(1),
+	titleLog: z.string().optional(),
+	descriptionLog: z.string().optional(),
+})
+	


### PR DESCRIPTION
Closes #10 

##  CheckList

- [x] TRPC application.deploy and application.redeploy endpoints accept optional title and description parameters
- [x] TRPC compose.deploy and compose.redeploy endpoints accept optional title and description parameters
- [x] External API /deploy endpoint accepts optional title and description parameters for all application types
- [x] When custom title/description are provided, they appear in the deployment history UI
- [x] When custom title/description are not provided, deployments use existing default titles ("Manual deployment", "Rebuild deployment", etc.) maintaining backward compatibility
- [x] Schema validation properly handles optional parameters and rejects invalid inputs
- [x] All existing deployments continue to work without modification

https://github.com/user-attachments/assets/1a0d065d-19ea-494e-b1e1-4ff96ded41f9



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional title/description to deployments via TRPC and external API, defaulting to commit message and hash when not provided.
> 
> - **Deploy API**:
>   - `apps/dokploy/pages/api/deploy/[refreshToken].ts`: Accepts optional `titleLog` and `descriptionLog` via query params; defaults to commit message and `Hash: <hash>`.
>   - Uses provided/default values in `DeploymentJob`.
> - **TRPC Routers**:
>   - `apps/dokploy/server/api/routers/application.ts`:
>     - `deploy`/`redeploy` now use `apiDeployApplication` and accept optional `titleLog`/`descriptionLog`; applied to `DeploymentJob` with defaults.
>   - `apps/dokploy/server/api/routers/compose.ts`:
>     - `deploy`/`redeploy` now use `apiDeployCompose` and accept optional `titleLog`/`descriptionLog`; applied to `DeploymentJob` with defaults.
> - **Schemas**:
>   - `packages/server/src/db/schema/application.ts`: Add `apiDeployApplication` with optional `titleLog`/`descriptionLog`.
>   - `packages/server/src/db/schema/compose.ts`: Add `apiDeployCompose` with optional `titleLog`/`descriptionLog`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78fc04fd3609b267d076bfd7c8762d394021cd5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->